### PR TITLE
add ability to add lib on pubspec.yaml file without open the file

### DIFF
--- a/src/functions/openInput.ts
+++ b/src/functions/openInput.ts
@@ -78,7 +78,6 @@ export async function openInput(context: vscode.ExtensionContext) {
     const preserveNewline = checkNewlineAtEndOfFile();
     formatDocument();
     const pubspecString = getPubspecText();
-    console.log(`pubspecString ${pubspecString}`);
     const originalLines = pubspecString.split("\n");
     const modifiedPubspec = addDependencyByText(pubspecString, chosenPackage);
     const newPubspecString = modifiedPubspec.result.concat(


### PR DESCRIPTION
Hi @jeroen-meijer 

Here my PR for your roadmap:
Ability to add dependencies without opening pubspec.yaml