### PR TITLE
feat: v2.0.0

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": false,
+  "semi": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,9 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    "cSpell.words": [
+        "mychaelgo",
+        "retryable"
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,3 +86,14 @@ First official release! 🎉
 
 - Changed status bar message icon to spinning sync icon.
 - Removed console logs.
+
+## 2.0.0 - 2020-08-06
+
+### Changed
+
+- **BREAKING**: Replaced old "text parser" with a proper implementation that uses the `yaml` package.
+- Added option for using the legacy text parser.
+- Added option for disabling the caret (`^`) for dependencies.
+- Filtered `dart:...` packages from search results.
+- Improved and updated README.md
+- Upgrade dependency versions for security reasons (again again).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Pubspec Assist is a Visual Studio Code extension that allows you to easily add d
 
 <img src="https://i.imgur.com/W2cGuPL.gif" style="width: 600px"/>
 
+## Usage
+
+Simply open the Command Palette (by default, `Ctrl+Shift+P` on Windows, `⌘+Shift+P` on Mac) and search for "Pubspec Assist".
+
+Then, choose any of the available options (see the video above).
+
 ## Download
 
 [Download the latest version here.](https://marketplace.visualstudio.com/items?itemName=jeroen-meijer.pubspec-assist)
@@ -14,11 +20,11 @@ Pubspec Assist is a Visual Studio Code extension that allows you to easily add d
 
 ### Get the latest version for your packages.
 
-**Pubspec Assist will get you the latest version of whatever package you are looking for** and puts it in your `pubspec.yaml` file while preserving comments and formats the file automatically. If you already have the package in your `pubspec.yaml`, Pubspec Assist automatically updates it to the latest version for you.
+**Pubspec Assist will get you the latest version of whatever package you are looking for** and puts it in your `pubspec.yaml` file while preserving comments and (most) empty lines and formats the file automatically. If you already have the package in your `pubspec.yaml`, Pubspec Assist automatically updates it to the latest version for you. Oh, and it also supports `dev_dependencies`!
 
 ### Never leave VS Code.
 
-**Forget going to the Dart Pub site to search for your packages and copy the dependency text.**<br/>
+**Forget going to the [pub.dev](https://pub.dev/) to search for your packages and copy the dependency text.**<br/>
 You can look for and import packages directly from VS Code without ever switching windows.
 
 ### Smart (Fuzzy) search.

--- a/package-lock.json
+++ b/package-lock.json
@@ -542,9 +542,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "log-symbols": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pubspec-assist",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -120,6 +120,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -342,7 +343,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "find-up": {
       "version": "3.0.0",
@@ -526,6 +528,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -814,7 +817,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "string-width": {
       "version": "2.1.1",
@@ -1047,6 +1051,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pubspec-assist",
   "displayName": "Pubspec Assist",
   "description": "Easily add and update dependencies to your Dart and Flutter project.",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "publisher": "jeroen-meijer",
   "author": {
     "name": "Jeroen Meijer",
@@ -57,12 +57,22 @@
     "configuration": [
       {
         "type": "object",
-        "title": "Pubspec Assist configuration",
+        "title": "Pubspec Assist",
         "properties": {
           "pubspec-assist.autoAddPackage": {
             "type": "boolean",
             "default": true,
             "description": "If a package with a very close match to your search is found, add it to the pubspec file automatically."
+          },
+          "pubspec-assist.useCaretSyntax": {
+            "type": "boolean",
+            "default": true,
+            "description": "Put a caret in front of the dependency version (i.e.: \"^1.0.0\" instead of \"1.0.0\")."
+          },
+          "pubspec-assist.useLegacyParser": {
+            "type": "boolean",
+            "default": false,
+            "description": "Use the legacy YAML text parser. Deprecated, should usually be turned off."
           }
         }
       }
@@ -92,8 +102,8 @@
   },
   "dependencies": {
     "fuse-js-latest": "^3.1.0",
-    "js-yaml": "^3.13.1",
     "openurl": "^1.1.1",
-    "typed-rest-client": "^1.7.3"
+    "typed-rest-client": "^1.7.3",
+    "yaml": "^1.10.0"
   }
 }

--- a/src/helper/getSettings.ts
+++ b/src/helper/getSettings.ts
@@ -1,0 +1,18 @@
+import * as vscode from "vscode";
+
+export type Settings = {
+  autoAddPackage: boolean;
+  useCaretSyntax: boolean;
+  useLegacyParser: boolean;
+};
+
+export const getSettings = () => {
+  const getSettingByKey = <T>(keyName: string): T | undefined =>
+    vscode.workspace.getConfiguration().get<T>(`pubspec-assist.${keyName}`);
+
+  return <Settings>{
+    autoAddPackage: getSettingByKey("autoAddPackage") ?? true,
+    useCaretSyntax: getSettingByKey("useCaretSyntax") ?? true,
+    useLegacyParser: getSettingByKey("useLegacyParser") ?? false,
+  };
+};

--- a/src/model/pubPackage.ts
+++ b/src/model/pubPackage.ts
@@ -29,8 +29,4 @@ export class PubPackage {
 
     return false;
   }
-
-  public generateDependencyString() {
-    return `${this.name}: ^${this.latestVersion}`;
-  }
 }

--- a/src/model/pubspecContext.ts
+++ b/src/model/pubspecContext.ts
@@ -1,11 +1,14 @@
 import { DependencyType } from "./dependencyType";
+import { Settings } from "../helper/getSettings";
 
 export type PubspecContext =
   | {
+      settings: Settings;
       dependencyType: DependencyType;
       openInEditor: true;
     }
   | {
+      settings: Settings;
       dependencyType: DependencyType;
       openInEditor: false;
       path: string;

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -29,6 +29,11 @@ suite("Extension: Dependency Adding Tests", function () {
           context: {
             openInEditor: true,
             dependencyType: "dependencies",
+            settings: {
+              autoAddPackage: true,
+              useCaretSyntax: true,
+              useLegacyParser: false,
+            }
           },
           pubspecString: pubspecMock.source,
           newPackage: testCase.pubPackage,


### PR DESCRIPTION
### Changed

- **BREAKING**: Replaced old "text parser" with a proper implementation that uses the `yaml` package.
- Added option for using the legacy text parser.
- Added option for disabling the caret (`^`) for dependencies.
- Filtered `dart:...` packages from search results.
- Improved and updated README.md
- Upgrade dependency versions for security reasons (again again).