### PR TITLE
Feature(PubPackages): Filter out versions that aren't compatible with…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pubspec-assist",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -72,6 +72,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ=="
     },
     "@types/vscode": {
       "version": "1.49.0",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "vscode-test": "^1.4.0"
   },
   "dependencies": {
+    "@types/semver": "^7.3.4",
     "fuse-js-latest": "^3.1.0",
     "openurl": "^1.1.1",
     "typed-rest-client": "^1.7.3",

--- a/src/model/pubPackage.ts
+++ b/src/model/pubPackage.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import * as semver from "semver";
 
 export class PubPackage {
@@ -35,7 +35,7 @@ export class PubPackage {
     } else {
       sdkPath = String(flutterPath) + '/bin/cache/dart-sdk/version'
     }
-    if (!sdkPath) return json['version']
+    if (!existsSync(sdkPath)) return json['version']
     let buffer = readFileSync(sdkPath)
     let dartVer = buffer.toString()
 

--- a/src/model/pubPackage.ts
+++ b/src/model/pubPackage.ts
@@ -1,3 +1,7 @@
+import * as vscode from "vscode";
+import { readFileSync } from "fs";
+import * as semver from "semver";
+
 export class PubPackage {
   constructor(
     name: string,
@@ -16,9 +20,37 @@ export class PubPackage {
   public static fromJSON(json: any): PubPackage {
     return new PubPackage(
       json["name"],
-      json["latest"]["version"],
+      this.getLatestCompatibleVersion(json),
       this.checkFlutterCompatibility(json)
     );
+  }
+
+  private static getLatestCompatibleVersion(json: any) : string {
+    // We get the current flutter sdk path from the vs configuration
+    let dartPath = vscode.workspace.getConfiguration('dart').get('sdkPath')
+    let flutterPath =  vscode.workspace.getConfiguration('dart').get('flutterSdkPath');
+    let sdkPath;
+    if (dartPath) {
+      sdkPath = String(dartPath) + '/version'
+    } else {
+      sdkPath = String(flutterPath) + '/bin/cache/dart-sdk/version'
+    }
+    if (!sdkPath) return json['version']
+    let buffer = readFileSync(sdkPath)
+    let dartVer = buffer.toString()
+
+    // We do a regex search just to be sure we are getting a valid semver string
+    let regex = RegExp(/(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)/);
+    let matches = regex.exec(dartVer);
+    let sdkVer = matches ? matches[0] : '';
+
+    // We filter out the versions that are not compatible with our SDK version
+    let filteredItems = json['versions'].filter((item: any, index: number, array: any) => {
+      let env = item['pubspec']['environment']['sdk'];
+      return semver.satisfies(sdkVer, env)
+    });
+
+    return filteredItems.pop()['version'] ?? json['version']
   }
 
   private static checkFlutterCompatibility(json: any): boolean {


### PR DESCRIPTION
… user's Dart SDK.

We need to thoroughly test this out because I'm not sure of the method we're using to retrieve the Dart SDK version. BTW, this is the only reliable *enough*  method I found to retrieve the SDK version and it is used by the official Dart VS Code extension.