### PR TITLE
feat: v2.3.2, sorting & naming fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the "pubspec-assist" extension will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.3.2 - 2021-11-04
+
+- fix: fix null reference exception when sorting dependencies with unbounded constraints using the legacy sorting system (fixes #97, #95, #89, #88, #76, #74, #73, #63)
+- fix: don't display "null" string for dependencies with unbounded constraints
+
 ## 2.3.1 - 2021-11-03
 
 - feat: properly handle errors when user's YAML file is not valid (closes #135, #134, #133, #131, #130, #129, #128, #127, #126, #125, #124, #123, #122, #121, #120, #116, #113, #112, #110, #108, #105, #104, #103, #102, #101, #100, #92, #90, #82, #79, #78, #75, #72, #67, #61)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Jeroen Meijer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "pubspec-assist",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.3.0",
+      "name": "pubspec-assist",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "fuse-js-latest": "^3.1.0",
@@ -28,7 +29,7 @@
         "vscode-test": "^1.6.1"
       },
       "engines": {
-        "vscode": "^1.49.0"
+        "vscode": "^1.61.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -347,7 +348,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pubspec-assist",
   "displayName": "Pubspec Assist",
   "description": "Easily add and update dependencies to your Dart and Flutter project.",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "publisher": "jeroen-meijer",
   "author": {
     "name": "Jeroen Meijer",


### PR DESCRIPTION
This PR fixes two issues in the sorting system.

- fix: fix null reference exception when sorting dependencies with unbounded constraints using the legacy sorting system
- fix: don't display "null" string for dependencies with unbounded constraints

<details>
<summary>Closing issues</summary>

Fixes #97
Fixes #95
Fixes #89
Fixes #88
Fixes #76
Fixes #74
Fixes #73
Fixes #63

</details>
