### PR TITLE
chore: release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Upcoming
 
+## 2.4.0 - 2026-07-01
+
 - fix(ci): drop tsc build-info cache that skipped compile output on CI
 - docs: update PR template
 - ci: add PR-only CI with lint, test, changelog, and semantic PR title checks

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pubspec-assist",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pubspec-assist",
-      "version": "2.3.2",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "fuse.js": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pubspec-assist",
   "displayName": "Pubspec Assist",
   "description": "Easily add and update dependencies to your Dart and Flutter project.",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "publisher": "jeroen-meijer",
   "author": {
     "name": "Jeroen Meijer",


### PR DESCRIPTION
## Description

This PR prepares release **2.4.0**: changelog section and `package.json` version bump.

Merge with **squash** after CI passes. Merging this PR (with the `release` label) publishes to the VS Code Marketplace and Open VSX (when configured), creates a GitHub release, and tags `main` with `2.4.0`.

To retry a failed publish without merging again: Actions → **Publish Release** → **Run workflow** with version `2.4.0`.