### PR TITLE
ci: remove Open VSX publish from release pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,27 +89,6 @@ jobs:
           fi
           npx @vscode/vsce publish --packagePath "$(ls -1 *.vsix | head -1)" --no-dependencies
 
-  open-vsx:
-    name: Publish to Open VSX
-    needs: marketplace
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download VSIX artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: vsix
-          path: .
-
-      - name: Publish to Open VSX
-        env:
-          OVSX_PAT: ${{ secrets.OVSX_PAT }}
-        run: |
-          if [ -z "$OVSX_PAT" ]; then
-            echo "OVSX_PAT not configured, skipping Open VSX publish"
-            exit 0
-          fi
-          npx ovsx publish "$(ls -1 *.vsix | head -1)" -p "$OVSX_PAT"
-
   release:
     name: Create GitHub release
     needs: [verify-release, marketplace]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Upcoming
 
+- ci: remove Open VSX publish from release pipeline (extension mirrored via Eclipse auto-publish)
+
 ## 2.4.0 - 2026-07-01
 
 - fix(ci): drop tsc build-info cache that skipped compile output on CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Start with “This PR …” in one clear sentence. Add bullets or notes below o
 1. Add bullets under `## Upcoming` in `CHANGELOG.md`.
 2. Merge feature PRs to `main` after CI passes.
 3. Run `./tool/prepare_release.sh X.Y.Z` → release PR on `chore/release-X.Y.Z` with the **`release`** label.
-4. Squash-merge the release PR → **Publish Release** publishes to VS Code Marketplace (+ Open VSX when `OVSX_PAT` is set), creates a GitHub release with the `.vsix`, and tags `main` with `X.Y.Z`.
+4. Squash-merge the release PR → **Publish Release** publishes to VS Code Marketplace, creates a GitHub release with the `.vsix`, and tags `main` with `X.Y.Z`. Open VSX is updated separately via [Eclipse auto-publish](https://github.com/EclipseFdn/open-vsx.org/wiki/Auto-Publishing-Extensions).
 5. If publish fails after merge: Actions → **Publish Release** → **Run workflow** with the same version.
 
 ## Project-Specific Guardrails
@@ -104,7 +104,7 @@ Start with “This PR …” in one clear sentence. Add bullets or notes below o
 ## Secrets
 
 - `VSCE_PAT` — Azure DevOps PAT with Marketplace **Manage** scope (GitHub Actions secret).
-- `OVSX_PAT` — Open VSX token (GitHub Actions secret, optional).
+- `OVSX_PAT` — Open VSX token (GitHub Actions secret, optional; reserved for future direct publish — not used by CI while auto-publish mirrors Marketplace releases).
 - Local copies live in `.ci.env` (gitignored). Never commit secrets.
 
 ## What Not to Add

--- a/README.md
+++ b/README.md
@@ -87,5 +87,5 @@ Releases are cut via labeled release PRs, not manual version bumps on `main`:
 
 This opens `chore/release-X.Y.Z` with the `release` label. Squash-merge after CI passes to publish to the VS Code Marketplace, create a GitHub release, and tag `main`.
 
-First-time setup requires the `release` label and `VSCE_PAT` / `OVSX_PAT` secrets in GitHub Actions (see CLAUDE.md).
+First-time setup requires the `release` label and `VSCE_PAT` in GitHub Actions (see CLAUDE.md). Open VSX updates are handled by Eclipse auto-publish from the Marketplace.
 

--- a/tool/prepare_release.sh
+++ b/tool/prepare_release.sh
@@ -85,7 +85,7 @@ gh pr create \
 
 This PR prepares release **${VERSION}**: changelog section and \`package.json\` version bump.
 
-Merge with **squash** after CI passes. Merging this PR (with the \`${RELEASE_LABEL}\` label) publishes to the VS Code Marketplace and Open VSX (when configured), creates a GitHub release, and tags \`main\` with \`${VERSION}\`.
+Merge with **squash** after CI passes. Merging this PR (with the \`${RELEASE_LABEL}\` label) publishes to the VS Code Marketplace, creates a GitHub release, and tags \`main\` with \`${VERSION}\`.
 
 To retry a failed publish without merging again: Actions → **Publish Release** → **Run workflow** with version \`${VERSION}\`.
 EOF


### PR DESCRIPTION
## Description

This PR removes the Open VSX publish job from the release workflow. The extension is already mirrored to Open VSX via Eclipse auto-publish from the VS Code Marketplace, and direct publish failed due to namespace access. `OVSX_PAT` remains documented in CLAUDE.md for future use.