### PR TITLE
fix: command 'pubspec-assist.sortAllDependencies' not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Upcoming
 
+- fix: stop passing `--no-dependencies` to `vsce package`/`vsce publish` — the extension isn't bundled, so this stripped `node_modules` (`yaml`, `fuse.js`) from the VSIX and made the extension fail to activate on install (fixes "command 'pubspec-assist.sortAllDependencies' not found" regression from 2.4.0)
 - ci: remove Open VSX publish from release pipeline (extension mirrored via Eclipse auto-publish)
 
 ## 2.4.0 - 2026-07-01

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Start with “This PR …” in one clear sentence. Add bullets or notes below o
 - IMPORTANT: `pubspec.yaml` must be a valid YAML map at the root. Malformed files can crash the extension — handle errors gracefully when touching parsing code.
 - IMPORTANT: Package search requires network access to pub.dev.
 - Do not use deprecated `workspace.rootPath` — use `workspace.workspaceFolders` for multi-root workspaces.
-- Runtime deps (`fuse.js`, `yaml`) are compiled to `out/`; use `vsce package --no-dependencies` for publishing.
+- IMPORTANT: Runtime deps (`fuse.js`, `yaml`) are NOT bundled into `out/` (plain `tsc`, no bundler) — `vsce package`/`vsce publish` must run *without* `--no-dependencies`, or the VSIX ships without `node_modules` and the extension fails to activate on install.
 
 ## Secrets
 

--- a/package.json
+++ b/package.json
@@ -95,8 +95,8 @@
     "lint": "eslint --cache --cache-location .eslintcache src",
     "pretest": "npm run compile",
     "test": "mocha -u tdd 'out/test/**/*.test.js'",
-    "package": "vsce package --no-dependencies",
-    "vscode:publish": "vsce publish --no-dependencies"
+    "package": "vsce package",
+    "vscode:publish": "vsce publish"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",


### PR DESCRIPTION
Runtime deps (yaml, fuse.js) are not bundled, so --no-dependencies stripped node_modules from the VSIX causing activation failure.