### PR TITLE
fix: await async callback in getValue to enable retry on network errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Upcoming
 
+- fix: await pub.dev API callback in `getValue` so network errors trigger the retry prompt instead of failing silently
 - ci: remove Open VSX publish from release pipeline (extension mirrored via Eclipse auto-publish)
 
 ## 2.4.0 - 2026-07-01

--- a/src/helper/getValue.ts
+++ b/src/helper/getValue.ts
@@ -7,7 +7,7 @@ const getValue = async <T>(f: () => T) => {
 
   while (tryAgain) {
     try {
-      value = f();
+      value = await f();
       tryAgain = false;
     } catch (error) {
       if (error instanceof PubApiNotRespondingError) {


### PR DESCRIPTION
## Description

This PR awaits the callback inside `getValue` so that rejected promises from the pub.dev API calls are caught by the retry logic instead of escaping unhandled, fixing the retry-on-network-error mechanism.
